### PR TITLE
Only remove top-level print statements

### DIFF
--- a/LiterateSwift.podspec
+++ b/LiterateSwift.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "LiterateSwift"
-  s.version      = "0.0.19"
+  s.version      = "0.0.20"
   s.summary      = "Literate Swift is a framework for doing literate programming in Swift"
 
   s.description  = <<-DESC

--- a/LiterateSwift.podspec
+++ b/LiterateSwift.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "LiterateSwift"
-  s.version      = "0.0.14"
+  s.version      = "0.0.19"
   s.summary      = "Literate Swift is a framework for doing literate programming in Swift"
 
   s.description  = <<-DESC

--- a/LiterateSwift.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/LiterateSwift.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/LiterateSwift/Evaluation.swift
+++ b/LiterateSwift/Evaluation.swift
@@ -75,5 +75,33 @@ func evaluateSwift(code: String, expression: String) -> String {
     let workingDirectory = NSFileManager.defaultManager().currentDirectoryPath
     let (stdout, stderr) = exec(commandPath: "/tmp/app", workingDirectory: workingDirectory, arguments: [workingDirectory])
     printstderr(stderr)
-    return stdout
+    return stdout.wrap(70)
 }
+
+extension String {
+    func wrap(length: Int) -> String {
+        let wrapChars: [Character] = [" ", ","]
+        var wrapped: [String] = []
+        var start = startIndex
+        var end = start
+        while end < endIndex {
+            while end < endIndex && start.distanceTo(end) < length {
+                end = end.advancedBy(1)
+            }
+            if end != endIndex {
+                var retractedEnd = end
+                while start.distanceTo(retractedEnd) > 0 && !wrapChars.contains(self[retractedEnd.advancedBy(-1)]) {
+                    retractedEnd = retractedEnd.advancedBy(-1)
+                }
+                if !self[start..<retractedEnd].trimmed.isEmpty {
+                    end = retractedEnd
+                }
+            }
+            let l = String(self[start..<end]).trimmed
+            wrapped.append(l)
+            start = end
+        }
+        return wrapped.joinWithSeparator("\n")
+    }
+}
+

--- a/LiterateSwift/LiterateSwift.swift
+++ b/LiterateSwift/LiterateSwift.swift
@@ -73,7 +73,8 @@ public func isEmbedPrintSwift(block: Block) -> (String,String)? {
 
 public func evaluateAndReplacePrintSwift(document: [Block], workingDirectory: NSURL) -> [Block] {
     let isPrintSwift = { codeBlock($0, { $0 == "print-swift" }) }
-    let swiftCode = deepCollect(document, extractSwift).joinWithSeparator("\n").stringByReplacingOccurrencesOfString("print(", withString: "noop_print(")
+    let swiftCode = deepCollect(document, extractSwift).joinWithSeparator("\n")
+//        .stringByReplacingOccurrencesOfString("print(", withString: "noop_print(")
     let prelude = [
         "func noop_print<T, TargetStream : OutputStreamType>(value: T, inout _ target: TargetStream, appendNewline: Bool) { }",
         "func noop_print<T, TargetStream : OutputStreamType>(value: T, inout _ target: TargetStream) { }",

--- a/LiterateSwift/LiterateSwift.swift
+++ b/LiterateSwift/LiterateSwift.swift
@@ -94,7 +94,7 @@ func resultBlocks(printableCode: String, prelude: String, expression: String, me
 public func evaluateAndReplacePrintSwift(document: [Block], workingDirectory: NSURL, mergeCodeBlocks: Bool = false) -> [Block] {
     let isPrintSwift = { codeBlock($0, { $0 == "print-swift" }) }
     let swiftCode = deepCollect(document, extractSwift).joinWithSeparator("\n")
-//        .stringByReplacingOccurrencesOfString("print(", withString: "noop_print(")
+        .stringByReplacingOccurrencesOfString("\nprint(", withString: "\nnoop_print(")
     let prelude = [
         "func noop_print<T, TargetStream : OutputStreamType>(value: T, inout _ target: TargetStream, appendNewline: Bool) { }",
         "func noop_print<T, TargetStream : OutputStreamType>(value: T, inout _ target: TargetStream) { }",


### PR DESCRIPTION
If we remove all print statements (also the ones appearing in functions) we might not get the full output if using "print-swift". This does not apply to "embed-print-swift", since the substitution is not performed there.
